### PR TITLE
chore: clarify that retry behavior is to be configurable at the API l…

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ We expect that you will spend roughly 2 hours on this assignment, but please spe
 
 ## Requirements
 - Each email must be sent at most once
-- EmailRequests should have configurable retry behavior that applies to retriable errors
+- EmailRequests should have configurable retry behavior that applies to retriable errors. This must be configurable at the EmailRequest level, not controller-wide.
 - Emails that are "bounced" should be treated as permanent failures and not retried.
 - Emails that are "blocked" should be treated as temporary failures and retried based on the configured retry behavior.
 - Invalid email addresses should be treated as permanent failures and not retried.


### PR DESCRIPTION
Candidates that cloned before this clarification was made will not be penalized whatsoever. However, upon reviewing several submissions, it is now clear that this requirement caused confusion.

---

* chore: clarify that retry behavior is to be configurable at the API level, not controller-wide (78d1d70)
      