### PR TITLE
chore: clarify various requirements and extend the fakeemail module

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,18 +11,21 @@ A fake email service has been provided for you to use in your controller (`./pkg
 We expect that you will spend roughly 2 hours on this assignment, but please spend no more than 4 hours. An incomplete submission followed-up with good answers in the first interview round is better than a perfect submission and poor answers during the interview.
 
 ## Requirements
-- Each email must be sent at most once
-- EmailRequests should have configurable retry behavior that applies to retriable errors. This must be configurable at the API level, not controller-wide.
+- Each email must be sent at most once, including in the face of network failures, program panics, or runtime errors.
+  - You can ignore cases such as power loss, OOMKill, and other unexpected shutdown events.
+- EmailRequests should have configurable exponential-backoff retry behavior that applies to retriable errors. This should be configurable on a per-EmailRequest basis rather than via controller-wide configuration. (Hint: Design the EmailRequest API well!)
+  - The base delay and maximum delay components of your exponential backoff behavior must be configurable. You can ignore jitter.
 - Emails that are "bounced" should be treated as permanent failures and not retried.
 - Emails that are "blocked" should be treated as temporary failures and retried based on the configured retry behavior.
 - Invalid email addresses should be treated as permanent failures and not retried.
-- Your status API for `EmailRequest` should include status conditions that indicate whether the email has been sent successfully (among any other status information you deem important to expose)
+- Your status API for `EmailRequest` should include [status conditions](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Condition) that indicate whether the email has been sent successfully (among any other status information you deem important to expose).
 
 ## Bonus points
 
 Submissions that go "above and beyond" might include any or all of the following. Do note that this is optional, but encouraged, based on your available time.
-- Regex-based validation of email addresses at the API level. This could be via kubebuilder markers or via a validating webhook. You can use the same regex that the fakeemail service uses: `^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$` 
 - Tests that cover your controller's retry semantics and status API. See the [kubebuilder docs](https://book.kubebuilder.io/cronjob-tutorial/writing-tests) on writing tests for guidance.
+- Regex-based validation of email addresses at the API level. This could be via kubebuilder markers or via a validating webhook. You can use the same regex that the fakeemail service uses: `^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`
+  - NOTE: if you implement this, your controller should still handle invalid email address errors from the fake email service, regardless of whether or not you are catching them via the same regex at the API level.
 
 
 ## Next steps

--- a/cmd/example/example.go
+++ b/cmd/example/example.go
@@ -32,7 +32,11 @@ func main() {
 	}
 
 	// Simulate sending an email.
-	err = emailService.Send("recipient@example.com", "Hello", "This is a test email.")
+	emailID, err := emailService.Send(fakeemail.Email{
+		DestinationAddress: "recipient@example.com",
+		Subject:            "Hello",
+		Body:               "This is a test email.",
+	})
 	if err != nil {
 		switch {
 		case err.(*fakeemail.ErrInvalidEmailAddress) != nil:
@@ -45,4 +49,6 @@ func main() {
 			fmt.Printf("Error: %v\n", err)
 		}
 	}
+
+	fmt.Printf("Consistent identifier for this email: %v", emailID)
 }

--- a/pkg/fakeemail/email_types.go
+++ b/pkg/fakeemail/email_types.go
@@ -1,0 +1,35 @@
+package fakeemail
+
+import "hash/fnv"
+
+type Email struct {
+	DestinationAddress string
+	Subject            string
+	Body               string
+}
+
+// EmailIdentifier is a 32-bit unsigned integer that is produced by hashing the
+// destination address, subject line, and message body of an email. A given set
+// of inputs will always produce the same output. For the purposes of this assignment,
+// ignore the infinitisimal chance of hash collisions.
+type EmailIdentifier uint32
+
+func (e Email) hash() uint32 {
+	h := fnv.New32()
+
+	// hash the fields individually and combine with XOR (implicit)
+	h.Write([]byte(e.DestinationAddress))
+	h.Write([]byte(e.Subject))
+	h.Write([]byte(e.Body))
+
+	return h.Sum32()
+}
+
+// ID() returns the EmailIdentifier for an Email
+// EmailIdentifier is a 32-bit unsigned integer that is produced by hashing the
+// destination address, subject line, and message body of an email. A given set
+// of inputs will always produce the same output. For the purposes of this assignment,
+// ignore the infinitisimal chance of hash collisions.
+func (e Email) ID() EmailIdentifier {
+	return EmailIdentifier(e.hash())
+}

--- a/pkg/fakeemail/fakeemail_test.go
+++ b/pkg/fakeemail/fakeemail_test.go
@@ -19,10 +19,19 @@ func TestSendValidEmail(t *testing.T) {
 		t.Fatalf("Error creating EmailService: %v", err)
 	}
 
-	err = emailService.Send("recipient@example.com", "Test Subject", "This is the email body.")
+	email := Email{
+		DestinationAddress: "recipient@example.com",
+		Subject:            "Test Subject",
+		Body:               "This is the email body.",
+	}
+
+	emailID, err := emailService.Send(email)
 	if err != nil {
 		t.Errorf("Expected no error, got: %v", err)
 	}
+
+	// You can now use emailID as needed.
+	fmt.Printf("Email sent successfully. Email ID: %d\n", emailID)
 }
 
 func TestSendInvalidEmail(t *testing.T) {
@@ -37,12 +46,22 @@ func TestSendInvalidEmail(t *testing.T) {
 		t.Fatalf("Error creating EmailService: %v", err)
 	}
 
-	err = emailService.Send("invalid_email", "Test Subject", "This is the email body.")
+	email := Email{
+		DestinationAddress: "invalid_email",
+		Subject:            "Test Subject",
+		Body:               "This is the email body.",
+	}
+
+	emailID, err := emailService.Send(email)
 	if _, ok := err.(*ErrInvalidEmailAddress); !ok {
 		t.Errorf("Expected ErrInvalidEmailAddress, got: %v", err)
 	}
 
-	assertLogs(t, config.Logger, []string{})
+	// You can still use emailID, even if there was an error.
+	fmt.Printf("Email ID: %d\n", emailID)
+
+	// Assert that the logger contains the expected log entry
+	assertLogs(t, config.Logger, []string{"Invalid email address: invalid_email"})
 }
 
 func TestSendSimulatedBounce(t *testing.T) {
@@ -57,10 +76,19 @@ func TestSendSimulatedBounce(t *testing.T) {
 		t.Fatalf("Error creating EmailService: %v", err)
 	}
 
-	err = emailService.Send("recipient@example.com", "Test Subject", "This is the email body.")
+	email := Email{
+		DestinationAddress: "recipient@example.com",
+		Subject:            "Test Subject",
+		Body:               "This is the email body.",
+	}
+
+	emailID, err := emailService.Send(email)
 	if _, ok := err.(*ErrEmailBounced); !ok {
 		t.Errorf("Expected ErrEmailBounced, got: %v", err)
 	}
+
+	// You can still use emailID, even if there was an error.
+	fmt.Printf("Email ID: %d\n", emailID)
 
 	assertLogs(t, config.Logger, []string{"Simulating email bounce: recipient@example.com"})
 }
@@ -77,20 +105,92 @@ func TestSendSimulatedBlock(t *testing.T) {
 		t.Fatalf("Error creating EmailService: %v", err)
 	}
 
-	err = emailService.Send("recipient@example.com", "Test Subject", "This is the email body.")
+	email := Email{
+		DestinationAddress: "recipient@example.com",
+		Subject:            "Test Subject",
+		Body:               "This is the email body.",
+	}
+
+	emailID, err := emailService.Send(email)
 	if _, ok := err.(*ErrEmailBlocked); !ok {
 		t.Errorf("Expected ErrEmailBlocked, got: %v", err)
 	}
 
+	// You can still use emailID, even if there was an error.
+	fmt.Printf("Email ID: %d\n", emailID)
+
 	assertLogs(t, config.Logger, []string{"Simulating email block: recipient@example.com"})
 }
 
+func TestSendWithInvalidEmailLogger(t *testing.T) {
+	config := Config{
+		BounceRate: 0.0, // No simulated bounce.
+		BlockRate:  0.0, // No simulated block.
+		Logger:     log.New(&testLogger{logs: &[]string{}}, "", 0),
+	}
+
+	emailService, err := NewEmailService(config)
+	if err != nil {
+		t.Fatalf("Error creating EmailService: %v", err)
+	}
+
+	// Set an invalid email address
+	email := Email{
+		DestinationAddress: "invalid_email",
+		Subject:            "Test Subject",
+		Body:               "This is the email body.",
+	}
+
+	emailID, err := emailService.Send(email)
+	if _, ok := err.(*ErrInvalidEmailAddress); !ok {
+		t.Errorf("Expected ErrInvalidEmailAddress, got: %v", err)
+	}
+
+	// You can still use emailID, even if there was an error.
+	fmt.Printf("Email ID: %d\n", emailID)
+
+	// Assert that the logger contains the expected log entry
+	assertLogs(t, config.Logger, []string{"Invalid email address: invalid_email"})
+}
+
+func TestEqualEmailsProduceEqualIdentifiers(t *testing.T) {
+	// Create two identical emails
+	email1 := Email{
+		DestinationAddress: "recipient@example.com",
+		Subject:            "Test Subject",
+		Body:               "This is the email body.",
+	}
+
+	email2 := Email{
+		DestinationAddress: "recipient@example.com",
+		Subject:            "Test Subject",
+		Body:               "This is the email body.",
+	}
+
+	// Get the identifiers without sending emails
+	emailID1 := email1.ID()
+	emailID2 := email2.ID()
+
+	// Ensure that the identifiers are equal
+	if emailID1 != emailID2 {
+		t.Errorf("Expected equal identifiers for identical emails, got %d and %d", emailID1, emailID2)
+	}
+
+	// You can use emailID1 or emailID2 as needed.
+	fmt.Printf("Email IDs: %d and %d\n", emailID1, emailID2)
+}
+
+// Helper function to assert logs in the logger.
 func assertLogs(t *testing.T, logger *log.Logger, expectedLogs []string) {
 	t.Helper()
 
+	actualLogs := loggerStringSlice(logger)
+	defer func() {
+		t.Logf("Actual logs: %v", actualLogs)
+	}()
+
 	if len(expectedLogs) != 0 {
 		// If we expect logs, convert actual logs to string slices.
-		actualLogs := loggerStringSlice(logger)
 		if len(actualLogs) != len(expectedLogs) {
 			t.Errorf("Expected %d log entries, got %d", len(expectedLogs), len(actualLogs))
 		}
@@ -102,13 +202,13 @@ func assertLogs(t *testing.T, logger *log.Logger, expectedLogs []string) {
 		}
 	} else {
 		// If we expect no logs, ensure the logger has no entries.
-		actualLogs := loggerStringSlice(logger)
 		if len(actualLogs) != 0 {
 			t.Errorf("Expected no logs, but got %d log entries", len(actualLogs))
 		}
 	}
 }
 
+// Helper function to convert logger entries to a string slice.
 func loggerStringSlice(logger *log.Logger) []string {
 	// Helper function to convert logger entries to a string slice.
 	logs := logger.Writer().(*testLogger).logs
@@ -119,23 +219,28 @@ func loggerStringSlice(logger *log.Logger) []string {
 	return trimmedLogs
 }
 
+// Helper type for testing logging.
 type testLogger struct {
 	logs *[]string
 }
 
+// Helper function to create a new test logger.
 func newTestLogger() *log.Logger {
 	return log.New(&testLogger{logs: &[]string{}}, "", 0)
 }
 
+// Implementation of the Write method for the testLogger type.
 func (tl *testLogger) Write(p []byte) (n int, err error) {
 	*tl.logs = append(*tl.logs, string(p))
 	return len(p), nil
 }
 
+// Implementation of the Println method for the testLogger type.
 func (tl *testLogger) Println(v ...interface{}) {
 	*tl.logs = append(*tl.logs, fmt.Sprintln(v...))
 }
 
+// Implementation of the Printf method for the testLogger type.
 func (tl *testLogger) Printf(format string, v ...interface{}) {
 	*tl.logs = append(*tl.logs, fmt.Sprintf(format, v...))
 }


### PR DESCRIPTION
---

* chore: clarify various requirements and extend the fakeemail module to assist (af073fe)
      
      Clarifies requirements surrounding:
       - At-most-once delivery
       - What configurable retry behavior means and where it should be configured
       - Status conditions
      
      This commit also improves the fakeemail client to aid in the requirement that emails be sent at most
      once (barring power loss, OOM, or other unexpected shutdown events). The fakeemail client now offers
      an Email API and a hash-based Email identifier. The Send(...) function returns this identifier for ease
      of use, but users can also use Email::ID().